### PR TITLE
Use global regex

### DIFF
--- a/ewhere.go
+++ b/ewhere.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+var placeholderRE = regexp.MustCompile(`\?([\w\.]+)`)
+
 // Parse replaces dynamic placeholders in SQL with real fields and arguments.
 //
 // Example:
@@ -26,7 +28,7 @@ import (
 //
 // This function is designed to support dynamic SQL generation safely.
 func Parse(query string, params map[string]any) (string, []any) {
-	re := regexp.MustCompile(`\?([\w\.]+)`)
+	re := placeholderRE
 	matches := re.FindAllStringSubmatch(query, -1)
 
 	args := []any{}


### PR DESCRIPTION
## Summary
- define `placeholderRE` regex once
- reuse `placeholderRE` in `Parse`

## Testing
- `go test -v -coverprofile=coverage.out .`


------
https://chatgpt.com/codex/tasks/task_e_68400326a80483319dddd86ec1926637